### PR TITLE
Fix for Turkish "small dotless i" problem in Utf8::toAscii

### DIFF
--- a/class/Patchwork/Utf8.php
+++ b/class/Patchwork/Utf8.php
@@ -41,6 +41,11 @@ class Utf8
         if (preg_match("/[\x80-\xFF]/", $s))
         {
             $s = n::normalize($s, n::NFKD);
+
+            // Temporary fix for Turkish "small dotless i" issue until Unicode fix this
+            // see http://unicode.org/cldr/trac/ticket/2970 and http://unicode.org/cldr/trac/ticket/3335
+            $s = preg_replace('#\x{0131}#u', 'i', $s);
+
             $s = preg_replace('/\p{Mn}+/u', '', $s);
             $s = iconv('UTF-8', 'ASCII' . ('glibc' !== ICONV_IMPL ? '//IGNORE' : '') . '//TRANSLIT', $s);
         }


### PR DESCRIPTION
Currently when you have an "ı" (small dotless i) in your string, Utf8::toAscii doesn't convert properly this character. "ı" converted to "?" instead of "i".

This is a [known Unicode CLDR bug](http://unicode.org/cldr/trac/ticket/2970) opened 3 years ago and does not seem to be fixed. They said "it should be fixed next release, in bug [#3335](http://unicode.org/cldr/trac/ticket/3335)" which opened 2 years ago.
I don't know when they fix that, but that bug causes problem like this one laravel/framework#552
