### PR TITLE
Prevent multiple "bootups" from occuring if the class is loaded twice

### DIFF
--- a/bootup.utf8.php
+++ b/bootup.utf8.php
@@ -12,6 +12,11 @@ use Normalizer as n;
 use Patchwork\Utf8 as u;
 use Patchwork\PHP\Shim as s;
 
+// Don't bootup multiple times
+
+if (defined('PATCHWORK-UTF8_LOADED')) return;
+define('PATCHWORK-UTF8_LOADED', true);
+
 
 // Check PCRE
 


### PR DESCRIPTION
So this is based off your current tag, but not the latest commit.  The error I'm getting with your current tag is "Fatal error: Class 'Normalizer' not found in .../vendor/patchwork/utf8/class/Patchwork/Utf8/bootup.php on line 292" because the autoloader of my app (Laravel 4/Composer) is loading utf8 twice, once for the app and once for the package I'm working on in the Laravel workbench.

I tried your most recent commit, but I get a "Fatal error: Class 'Normalizer' not found in /Users/reinhard/Work/BKWLD/Open Source/Laravel 4 Packages/vendor/patchwork/utf8/class/Patchwork/Utf8/bootup.php on line 292" during the composer install.

This commit **does** fix my issue.
