### PR TITLE
Make sure the HTML-ENTITIES check isn't case sensitive.

### DIFF
--- a/class/Patchwork/PHP/Shim/Mbstring.php
+++ b/class/Patchwork/PHP/Shim/Mbstring.php
@@ -86,14 +86,14 @@ class Mbstring
 
         if ('base64' === $to_encoding) return base64_encode($s);
 
-        if ('html-entities' === $to_encoding)
+        if ('html-entities' === strtolower($to_encoding))
         {
             'html-entities' === $from_encoding && $from_encoding = 'Windows-1252';
             'utf-8' === $from_encoding || $s = iconv($from_encoding, 'UTF-8//IGNORE', $s);
             return preg_replace_callback('/[\x80-\xFF]+/', array(__CLASS__, 'html_encoding_callback'), $s);
         }
 
-        if ('html-entities' === $from_encoding)
+        if ('html-entities' === strtolower($from_encoding))
         {
             $s = html_entity_decode($s, ENT_COMPAT, 'UTF-8');
             $from_encoding = 'UTF-8';


### PR DESCRIPTION
I've recently been working with PHPUnit in Laravel on Windows and I ran into an error where I was getting an exception like the following:

```
iconv(): Wrong charset, conversion from `UTF-8' to `HTML-ENTITIES\/\/IGNORE' is not allowed
```

It mentioned the error being on line 102 in this file:

```
/vendor/patchwork/utf8/class/Patchwork/PHP/Shim/Mbstring.php
```

I did some debugging and found out that the `$to_encoding` was "HTML-ENTITIES" instead of "html-entities," causing the error to be thrown. I updated the source to use `strtolower` on the `$to_encoding` and `$from_encoding` conditionals and my tests ran without error.

Stepping up the code frames, I noticed the all-caps "HTML-ENTITIES" was coming from Symfony, so I'm sure I'm not the only one with this problem.
