### PR TITLE
add more mbstring shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.2.0 (2015-01-12)
+
+- add u::strwidth() to get the width of a string when printed on a terminal
+- add more mbstring shims
+- add a note about https://bugs.php.net/65358
+- fail properly when COM is not loaded
+- fallback on stat() when lstat() fails
+
 ## v1.2.0-beta (2014-08-05)
 
 - add best-fit mappings for UTF-8 to Code Page approximations

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ server even if one or more of those extensions are not enabled:
 - *utf8_encode, utf8_decode*,
 - `mbstring`: *mb_check_encoding, mb_convert_case, mb_convert_encoding,
   mb_decode_mimeheader, mb_detect_encoding, mb_detect_order,
-  mb_encode_mimeheader, mb_encoding_aliases, mb_internal_encoding, mb_language,
-  mb_list_encodings, mb_strlen, mb_strpos, mb_strrpos, mb_strtolower,
+  mb_encode_mimeheader, mb_encoding_aliases, mb_get_info, mb_http_input,
+  mb_http_output, mb_internal_encoding, mb_language, mb_list_encodings,
+  mb_output_handler, mb_strlen, mb_strpos, mb_strrpos, mb_strtolower,
   mb_strtoupper, mb_stripos, mb_stristr, mb_strrchr, mb_strrichr, mb_strripos,
-  mb_strstr, mb_substitute_character, mb_substr*,
+  mb_strstr, mb_strwidth, mb_substitute_character, mb_substr, mb_substr_count*,
 - `iconv`: *iconv, iconv_mime_decode, iconv_mime_decode_headers,
   iconv_get_encoding, iconv_set_encoding, iconv_mime_encode, ob_iconv_handler,
   iconv_strlen, iconv_strpos, iconv_strrpos, iconv_substr*,
@@ -66,7 +67,8 @@ Some more functions are also provided to help handling UTF-8 strings:
 - *isUtf8()*: checks if a string contains well formed UTF-8 data,
 - *toAscii()*: generic UTF-8 to ASCII transliteration,
 - *strtocasefold()*: unicode transformation for caseless matching,
-- *strtonatfold()*: generic case sensitive transformation for collation matching
+- *strtonatfold()*: generic case sensitive transformation for collation matching,
+- *strwidth()*: computes the width of a string when printed on a terminal,
 - *wrapPath()*: unicode filesystem access under Windows and other OSes.
 
 Mirrored string functions are:

--- a/class/Patchwork/Utf8/Bootup/mbstring.php
+++ b/class/Patchwork/Utf8/Bootup/mbstring.php
@@ -43,3 +43,9 @@ function mb_strrichr($s, $needle, $part = false, $enc = INF) {return s\Mbstring:
 function mb_strripos($s, $needle, $offset = 0, $enc = INF) {return s\Mbstring::mb_strripos($s, $needle, $offset, $enc);};
 function mb_strrpos($s, $needle, $offset = 0, $enc = INF) {return s\Mbstring::mb_strrpos($s, $needle, $offset, $enc);};
 function mb_strstr($s, $needle, $part = false, $enc = INF) {return s\Mbstring::mb_strstr($s, $needle, $part, $enc);};
+function mb_get_info($type = 'all') {return s\Mbstring::mb_get_info($type);}
+function mb_http_output($enc = INF) {return s\Mbstring::mb_http_output($enc);}
+function mb_strwidth($s, $enc = INF) {return s\Mbstring::mb_strwidth($s, $enc);}
+function mb_substr_count($haystack, $needle, $enc = INF) {return s\Mbstring::mb_substr_count($haystack, $needle, $enc);}
+function mb_output_handler($contents, $status) {return s\Mbstring::mb_output_handler($contents, $status);}
+function mb_http_input($type = '') {return s\Mbstring::mb_http_input($type);}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "lib-pcre": ">=7.3"
     },
     "suggest": {
+        "ext-wfio": "Use WFIO for UTF-8 filesystem access on Windows",
         "ext-intl": "Use Intl for best performance",
         "ext-iconv": "Use iconv for best performance",
         "ext-mbstring": "Use Mbstring for best performance"

--- a/tests/Patchwork/Tests/PHP/Shim/MbstringTest.php
+++ b/tests/Patchwork/Tests/PHP/Shim/MbstringTest.php
@@ -247,4 +247,14 @@ class MbstringTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('utf8'), p::mb_encoding_aliases('UTF-8'));
         $this->assertFalse(p::mb_encoding_aliases('ASCII'));
     }
+
+    /**
+     * @covers Patchwork\PHP\Shim\Mbstring::mb_strwidth
+     */
+    function testmb_strwidth()
+    {
+        $this->assertSame( 2, p::mb_strwidth("\0実") );
+        $this->assertSame( 4, p::mb_strwidth('déjà') );
+        $this->assertSame( 4, p::mb_strwidth(utf8_decode('déjà'), 'CP1252') );
+    }
 }


### PR DESCRIPTION
- [x] mb_get_info             - Get internal settings of mbstring
- [x] mb_http_input - Detect HTTP input character encoding
- [x] mb_http_output          - Set/Get HTTP output character encoding
- [ ] mb_strcut               - Get part of string
- [ ] mb_strimwidth           - Get truncated string with specified width
- [x] mb_strwidth             - Return width of string
- [x] mb_substr_count         - Count the number of substring occurrences
- [x] mb_output_handler - Callback function converts character encoding in output buffer
- [ ] add tests