### PR TITLE
iconv_set_encoding deprecated in PHP 5.6.0

### DIFF
--- a/class/Patchwork/Utf8/Bootup.php
+++ b/class/Patchwork/Utf8/Bootup.php
@@ -84,19 +84,25 @@ class Bootup
     {
         if (extension_loaded('iconv'))
         {
-            if ('UTF-8' !== iconv_get_encoding('input_encoding'))
+            if (PHP_VERSION_ID < 50600)
             {
-                iconv_set_encoding('input_encoding', 'UTF-8');
-            }
+                if ('UTF-8' !== iconv_get_encoding('input_encoding'))
+                {
+                    iconv_set_encoding('input_encoding', 'UTF-8');
+                }
 
-            if ('UTF-8' !== iconv_get_encoding('internal_encoding'))
-            {
-                iconv_set_encoding('internal_encoding', 'UTF-8');
-            }
+                if ('UTF-8' !== iconv_get_encoding('internal_encoding'))
+                {
+                    iconv_set_encoding('internal_encoding', 'UTF-8');
+                }
 
-            if ('UTF-8' !== iconv_get_encoding('output_encoding'))
-            {
-                iconv_set_encoding('output_encoding' , 'UTF-8');
+                if ('UTF-8' !== iconv_get_encoding('output_encoding'))
+                {
+                    iconv_set_encoding('output_encoding', 'UTF-8');
+                }
+            }
+            else {
+                ini_set('default_charset', 'UTF-8');
             }
         }
         else if (!defined('ICONV_IMPL'))


### PR DESCRIPTION
Since PHP 5.6.0, `iconv_set_encoding()` is deprecated in favour of `default_charset`.

http://php.net/manual/en/migration56.deprecated.php