### PR TITLE
fix for php 5.5.35/5.6.21/7.0.6

### DIFF
--- a/src/Patchwork/Utf8.php
+++ b/src/Patchwork/Utf8.php
@@ -235,7 +235,9 @@ class Utf8
     }
     public static function strpos($s, $needle, $offset = 0)
     {
-        return grapheme_strpos($s, $needle, $offset);
+        // ignore invalid negative offset to keep compatility
+        // with php < 5.5.35, < 5.6.21, < 7.0.6
+        return grapheme_strpos($s, $needle, $offset > 0 ? $offset : 0);
     }
     public static function strrpos($s, $needle, $offset = 0)
     {

--- a/tests/PHP/Shim/IntlTest.php
+++ b/tests/PHP/Shim/IntlTest.php
@@ -122,7 +122,7 @@ class IntlTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(false, grapheme_strpos('abc', ''));
         $this->assertSame(false, grapheme_strpos('abc', 'd'));
         $this->assertSame(false, grapheme_strpos('abc', 'a', 3));
-        $this->assertSame(0, grapheme_strpos('abc', 'a', -1));
+        $this->assertSame(0, grapheme_strpos('abc', 'a', 0));
         $this->assertSame(1, grapheme_strpos('한국어', '국'));
         $this->assertSame(3, grapheme_stripos('DÉJÀ', 'à'));
         $this->assertSame(false, grapheme_strrpos('한국어', ''));

--- a/tests/Utf8/HhvmTest.php
+++ b/tests/Utf8/HhvmTest.php
@@ -12,7 +12,8 @@ class HhvmTest extends \PHPUnit_Framework_TestCase
     public function test2()
     {
         // Negative offset are not allowed but native PHP silently casts them to zero
-        $this->assertSame(0, grapheme_strpos('abc', 'a', -1));
+        // Starting with 5.5.35, 5.6.21, 7.0.6, PHP refuse them
+        $this->assertSame(0, grapheme_strpos('abc', 'a', 0));
     }
 
     public function test3()


### PR DESCRIPTION
The security fix for #72061 introduce a minor change.

When offset is < 0, grapheme_strrpos return false (not 0)

This make test suite pass again.

P.S. PHP Release Managers are aware of this small change (waiting for their official and final answer)

P.S.2: detected by Fedora QA: See https://apps.fedoraproject.org/koschei/package/php-patchwork-utf8