### PR TITLE
check for MB_OVERLOAD_STRING define

### DIFF
--- a/src/Patchwork/Utf8/Bootup.php
+++ b/src/Patchwork/Utf8/Bootup.php
@@ -42,7 +42,7 @@ class Bootup
                 user_error('php.ini settings: Please disable mbstring.encoding_translation or set mbstring.http_input to "pass"',  E_USER_WARNING);
             }
 
-            if (MB_OVERLOAD_STRING & (int) ini_get('mbstring.func_overload')) {
+            if (defined('MB_OVERLOAD_STRING') && (MB_OVERLOAD_STRING & (int) ini_get('mbstring.func_overload'))) {
                 user_error('php.ini settings: Please disable mbstring.func_overload', E_USER_WARNING);
             }
 


### PR DESCRIPTION
MB_OVERLOAD_STRING is no longer available in PHP 8.0:
https://github.com/php/php-src/blob/master/UPGRADING