### PR TITLE
Replace the deprecated `each` with `current` and `next`

### DIFF
--- a/src/Patchwork/Utf8/WindowsStreamWrapper.php
+++ b/src/Patchwork/Utf8/WindowsStreamWrapper.php
@@ -106,7 +106,8 @@ class WindowsStreamWrapper
 
     public function dir_readdir()
     {
-        if (list(, $c) = each($this->handle)) {
+        if (($c = current($this->handle)) !== false) {
+            next($this->handle);
             return $c;
         }
 


### PR DESCRIPTION
Fixes https://github.com/tchwork/utf8/issues/74

But I have to admit as a Linux user I wasn't able to test this. So let's see what the Windows CI has to say.